### PR TITLE
#88 Implement `pazuzu build` for Git storage

### DIFF
--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -137,7 +137,39 @@ var buildCmd = cli.Command{
 
 // Fetches and builds features into a docker image.
 func buildFeatures(c *cli.Context) error {
-	return ErrNotImplemented
+	// TODO: Make file configurable via CLI args (GH Issue #102)
+	fileName := "Pazuzufile"
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Printf("Cannot find %s", fileName)
+		return err
+	}
+	defer file.Close()
+
+	config := pazuzu.GetConfig()
+	storageReader, err := pazuzu.GetStorageReader(config)
+
+	reader := bufio.NewReader(file)
+	pazuzuFile, err := pazuzu.Read(reader)
+
+	p := pazuzu.Pazuzu{StorageReader: storageReader}
+	p.Generate(pazuzuFile.Base, pazuzuFile.Features)
+
+	f, err := os.Create("Dockerfile")
+	if err != nil {
+		log.Print("could not create Dockerfile")
+		return err
+	}
+
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	w.Write(p.Dockerfile)
+	w.Flush()
+
+	return nil
+
 	// TODO: In case of -f/--feature-set option slice of features
 	// should be used instead of Pazuzufile
 

--- a/dockerfilewriter.go
+++ b/dockerfilewriter.go
@@ -3,8 +3,11 @@ package pazuzu
 import (
 	"bytes"
 	"fmt"
-	"github.com/docker/docker/builder/dockerfile/parser"
 	"strings"
+
+	"github.com/docker/docker/builder/dockerfile/parser"
+
+	"github.com/zalando-incubator/pazuzu/storageconnector"
 )
 
 var ErrInvalidCopyCmdSyntax = fmt.Errorf("Invalid 'COPY' command syntax")
@@ -27,7 +30,7 @@ func (c *DockerfileWriter) AppendRaw(chunk string) error {
 	return nil
 }
 
-func fixCopyCmd(node *parser.Node, feature Feature) (string, error) {
+func fixCopyCmd(node *parser.Node, feature storageconnector.Feature) (string, error) {
 	srcNode := node.Next
 	if srcNode == nil {
 		return "", ErrInvalidCopyCmdSyntax
@@ -37,16 +40,16 @@ func fixCopyCmd(node *parser.Node, feature Feature) (string, error) {
 		return "", ErrInvalidCopyCmdSyntax
 	}
 
-	fixedCmd := fmt.Sprintf("COPY %s/%s %s", feature.Name, srcNode.Value, dstNode.Value)
+	fixedCmd := fmt.Sprintf("COPY %s/%s %s", feature.Meta.Name, srcNode.Value, dstNode.Value)
 
 	return fixedCmd, nil
 }
 
-func (c *DockerfileWriter) AppendFeature(feature Feature) error {
+func (c *DockerfileWriter) AppendFeature(feature storageconnector.Feature) error {
 	d := parser.Directive{LookingForDirectives: true}
 	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
 
-	ast, err := parser.Parse(strings.NewReader(feature.DockerData), &d)
+	ast, err := parser.Parse(strings.NewReader(feature.Snippet), &d)
 	if err != nil {
 		return err
 	}

--- a/dockerfilewriter_test.go
+++ b/dockerfilewriter_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/zalando-incubator/pazuzu/storageconnector"
 )
 
 func TestDockerfileWriter(t *testing.T) {
@@ -32,7 +34,13 @@ func TestDockerfileWriter(t *testing.T) {
 	}
 
 	for _, f := range features {
-		err := writer.AppendFeature(Feature{Name: f.name, DockerData: f.data})
+		err := writer.AppendFeature(
+			storageconnector.Feature{
+				Meta: storageconnector.FeatureMeta{
+					Name: f.name,
+				},
+				Snippet: f.data,
+			})
 		if err != nil {
 			t.Fatalf("Feature should be appended: %s", err)
 		}

--- a/pazuzu_test.go
+++ b/pazuzu_test.go
@@ -2,31 +2,45 @@ package pazuzu
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/zalando-incubator/pazuzu/storageconnector"
 )
 
-type TestRegistry struct{}
+type TestStorage struct{}
 
-func (r TestRegistry) GetFeatures(features []string) ([]Feature, error) {
-	return []Feature{
-		Feature{
-			Name:            "python",
-			DockerData:      "RUN apt-get update && apt-get install python --yes",
-			TestInstruction: "python -V",
+func (s *TestStorage) GetFeature(feature string) (storageconnector.Feature, error) {
+	return storageconnector.Feature{
+		Meta: storageconnector.FeatureMeta{
+			Name:        "python",
+			Description: "Use `python -V`",
 		},
+		Snippet: "RUN apt-get update && apt-get install python --yes",
 	}, nil
 }
 
-func (r TestRegistry) FetchFiles(features Feature) (map[string]string, error) {
-	return make(map[string]string), nil
+func (s *TestStorage) GetMeta(name string) (storageconnector.FeatureMeta, error) {
+	return storageconnector.FeatureMeta{
+		Name:        "python",
+		Description: "Use `python -V`",
+	}, nil
+}
+
+func (s *TestStorage) SearchMeta(name *regexp.Regexp) ([]storageconnector.FeatureMeta, error) {
+	return make([]storageconnector.FeatureMeta, 0), nil
+}
+
+func (s *TestStorage) Resolve(names ...string) (map[string]storageconnector.Feature, error) {
+	return make(map[string]storageconnector.Feature), nil
 }
 
 // Test generating a Dockerfile from a list of features.
 func TestGenerate(t *testing.T) {
 	pazuzu := Pazuzu{
-		registry: TestRegistry{},
-		testSpec: "test_spec.json",
+		StorageReader: &TestStorage{},
+		testSpec:      "test_spec.json",
 	}
 
 	err := pazuzu.Generate("ubuntu", []string{"python"})
@@ -74,25 +88,12 @@ func TestWrite(t *testing.T) {
 func TestDockerBuild(t *testing.T) {
 	pazuzu := Pazuzu{
 		dockerEndpoint: "unix:///var/run/docker.sock",
-		dockerfile: []byte(`FROM ubuntu:latest
+		Dockerfile: []byte(`FROM ubuntu:latest
 RUN apt-get update && apt-get install python --yes`),
 		testSpec: "test_spec.json",
 	}
 
 	err := pazuzu.DockerBuild("test")
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
-}
-
-// Test verifying a docker image.
-func TestRunTestSpec(t *testing.T) {
-	pazuzu := Pazuzu{
-		dockerEndpoint: "unix:///var/run/docker.sock",
-		testSpec:       "test_spec.json",
-	}
-
-	err := pazuzu.RunTestSpec("test")
 	if err != nil {
 		t.Errorf("should not fail: %s", err)
 	}

--- a/storageconnector/gitstorage.go
+++ b/storageconnector/gitstorage.go
@@ -168,7 +168,7 @@ func getFeature(commit *git.Commit, name string) (Feature, error) {
 		return Feature{}, err
 	}
 
-	file, err := commit.File(path.Join(featureFile, name, featureSnippet))
+	file, err := commit.File(path.Join(featureDir, name, featureSnippet))
 	if err != nil {
 		if err == git.ErrFileNotFound {
 			return Feature{Meta: meta}, nil

--- a/storageconnector/gitstorage_test.go
+++ b/storageconnector/gitstorage_test.go
@@ -97,7 +97,7 @@ func TestGitStorage_Get(t *testing.T) {
 			t.Errorf("Feature name should be 'java' but was '%s'", feature.Meta.Name)
 		}
 
-		if feature.Snippet != "" {
+		if feature.Snippet == "" {
 			t.Error("Feature snippet should not be empty", feature.Snippet)
 		}
 	})


### PR DESCRIPTION
Issue #88 

📙 

⚠️ Breaks existing API integration. API integration still have to be rework in #98 .

⚠️ Removes the test for `test_spec.json` to be reworked in #96  