### PR TITLE
PAZUZU-102 Update `pazuzu compose` CLI

### DIFF
--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"text/tabwriter"
@@ -246,49 +244,5 @@ var buildCmd = cli.Command{
 
 // Fetches and builds features into a docker image.
 func buildFeatures(c *cli.Context) error {
-	// TODO: Make file configurable via CLI args (GH Issue #102)
-	fileName := "Pazuzufile"
-
-	file, err := os.Open(fileName)
-	if err != nil {
-		log.Printf("Cannot find %s", fileName)
-		return err
-	}
-	defer file.Close()
-
-	config := pazuzu.GetConfig()
-	storageReader, err := pazuzu.GetStorageReader(*config)
-
-	reader := bufio.NewReader(file)
-	pazuzuFile, err := pazuzu.Read(reader)
-
-	p := pazuzu.Pazuzu{StorageReader: storageReader}
-	p.Generate(pazuzuFile.Base, pazuzuFile.Features)
-
-	f, err := os.Create("Dockerfile")
-	if err != nil {
-		log.Print("could not create Dockerfile")
-		return err
-	}
-
-	defer f.Close()
-
-	w := bufio.NewWriter(f)
-	w.Write(p.Dockerfile)
-	w.Flush()
-
-	return nil
-
-	// TODO: In case of -f/--feature-set option slice of features
-	// should be used instead of Pazuzufile
-
-	// log.Print("Building Dockerfile out of the features")
-	// // TODO: check number of c.NArgs() and throw error if nothing was passed
-	// if c.NArg() == 0 {
-
-	// 	return errors.New(ERROR_NO_VALID_PAZUZU_FILE)
-
-	// }
-
-	// return nil
+	return ErrNotImplemented
 }

--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -10,6 +10,9 @@ import (
 	"github.com/zalando-incubator/pazuzu"
 )
 
+const PazuzufileName = "Pazuzufile"
+const DockerfileName = "Dockerfile"
+
 var cnfGetCmd = cli.Command{
 	Name:   "get",
 	Usage:  "Get pazuzu configuration",
@@ -159,7 +162,7 @@ var composeFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "d, destination",
-		Usage: "Sets destination for Docketfile and Pazuzufile to `DESTINATION`",
+		Usage: "Sets destination path for Docketfile and Pazuzufile to `DESTINATION`",
 	},
 }
 

--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -169,70 +169,8 @@ var composeCmd = cli.Command{
 	ArgsUsage: " ", // Do not show arguments
 	Description: "Compose step takes list of features as input, validates feature dependencies" +
 		" and creates both Pazuzufile and Dockerfile.",
-	Action: composeFiles,
 	Flags:  composeFlags,
-}
-
-var composeFiles = func(c *cli.Context) error {
-	var initFeatures = getFeaturesList(c.String("init"))
-	var addFeatures = getFeaturesList(c.String("add"))
-	var pazuzufileFeatures []string
-	var baseImage string
-
-	pazuzuFile, success := readPazuzuFile()
-	if success {
-		pazuzufileFeatures = pazuzuFile.Features
-		baseImage = pazuzuFile.Base
-	}
-
-	featureNames, err := generateFeaturesList(pazuzufileFeatures, initFeatures, addFeatures)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Resolving the following features: %s\n", featureNames)
-
-	config := pazuzu.GetConfig()
-	storageReader, err := pazuzu.GetStorageReader(*config)
-	if err != nil {
-		return err // TODO: process properly into human-readable message
-	}
-
-	features, err := checkFeaturesInRepository(featureNames, storageReader)
-	if err != nil {
-		return err
-	}
-
-	if baseImage == "" {
-		baseImage = config.Base
-	}
-
-	fmt.Print("Generating Pazuzufile...")
-
-	pazuzuFile = &pazuzu.PazuzuFile{
-		Base:     baseImage,
-		Features: features,
-	}
-
-	err = writePazuzuFile(pazuzuFile)
-	if err != nil {
-		return err
-	} else {
-		fmt.Println(" [DONE]")
-	}
-
-	fmt.Print("Generating Dockerfile...")
-
-	p := pazuzu.Pazuzu{StorageReader: storageReader}
-	p.Generate(pazuzuFile.Base, pazuzuFile.Features)
-
-	err = writeDockerFile(p.Dockerfile)
-	if err != nil {
-		return err
-	} else {
-		fmt.Println(" [DONE]")
-	}
-
-	return nil
+	Action: composeAction,
 }
 
 var buildCmd = cli.Command{

--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -239,8 +239,8 @@ var composeFiles = func(c *cli.Context) error {
 
 var buildCmd = cli.Command{
 	Name:      "build",
-	Usage:     "build Dockerfile out of Pazuzufile",
-	ArgsUsage: "[features] - This can be either path to Pazuzufile or a space separated feature names",
+	Usage:     "Builds and tests Docker image from Dockerfile",
+	ArgsUsage: " ",
 	Action:    buildFeatures,
 }
 

--- a/cli/pazuzu/compose.go
+++ b/cli/pazuzu/compose.go
@@ -1,0 +1,72 @@
+package main
+
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+	"github.com/zalando-incubator/pazuzu"
+)
+
+
+var composeAction = func(c *cli.Context) error {
+	var initFeatures = getFeaturesList(c.String("init"))
+	var addFeatures = getFeaturesList(c.String("add"))
+	var pazuzufileFeatures []string
+	var baseImage string
+
+	pazuzuFile, success := readPazuzuFile()
+	if success {
+		pazuzufileFeatures = pazuzuFile.Features
+		baseImage = pazuzuFile.Base
+	}
+
+	featureNames, err := generateFeaturesList(pazuzufileFeatures, initFeatures, addFeatures)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Resolving the following features: %s\n", featureNames)
+
+	config := pazuzu.GetConfig()
+	storageReader, err := pazuzu.GetStorageReader(*config)
+	if err != nil {
+		return err // TODO: process properly into human-readable message
+	}
+
+	features, err := checkFeaturesInRepository(featureNames, storageReader)
+	if err != nil {
+		return err
+	}
+
+	if baseImage == "" {
+		baseImage = config.Base
+	}
+
+	fmt.Print("Generating Pazuzufile...")
+
+	pazuzuFile = &pazuzu.PazuzuFile{
+		Base:     baseImage,
+		Features: features,
+	}
+
+	err = writePazuzuFile(pazuzuFile)
+	if err != nil {
+		return err
+	} else {
+		fmt.Println(" [DONE]")
+	}
+
+	fmt.Print("Generating Dockerfile...")
+
+	p := pazuzu.Pazuzu{StorageReader: storageReader}
+	p.Generate(pazuzuFile.Base, pazuzuFile.Features)
+
+	err = writeDockerFile(p.Dockerfile)
+	if err != nil {
+		return err
+	} else {
+		fmt.Println(" [DONE]")
+	}
+
+	return nil
+}

--- a/cli/pazuzu/error.go
+++ b/cli/pazuzu/error.go
@@ -8,4 +8,5 @@ var (
 	ErrTooFewOrManyParameters = errors.New("Too few/many parameters provided")
 	ErrStopIteration          = errors.New("It's not an real error, sorry!")
 	ErrNotFound               = errors.New("Not found")
+	ErrInitAndAddAreSpecified = errors.New("Conflict: both `add` and `init` parameters are specified")
 )

--- a/cli/pazuzu/utils.go
+++ b/cli/pazuzu/utils.go
@@ -13,6 +13,7 @@ import (
 )
 
 const PazuzufileName = "Pazuzufile"
+const DockerfileName = "Dockerfile"
 
 func getFeaturesList(featureString string) []string {
 	var features []string
@@ -88,6 +89,20 @@ func writePazuzuFile(pazuzuFile *pazuzu.PazuzuFile) error {
 	pazuzu.Write(writer, *pazuzuFile)
 
 	writer.Flush()
+	return nil
+}
+
+func writeDockerFile(contents []byte) error {
+	file, err := os.Create(DockerfileName)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not create %v", DockerfileName))
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	writer.Write(contents)
+	writer.Flush()
+
 	return nil
 }
 

--- a/cli/pazuzu/utils.go
+++ b/cli/pazuzu/utils.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/zalando-incubator/pazuzu"
+	"github.com/zalando-incubator/pazuzu/storageconnector"
+)
+
+const PazuzufileName = "Pazuzufile"
+
+func getFeaturesList(featureString string) []string {
+	var features []string
+
+	featureString = strings.Trim(featureString, ", ")
+	if len(featureString) > 0 {
+		for _, element := range strings.Split(featureString, ",") {
+			features = append(features, strings.Trim(element, " "))
+		}
+	}
+
+	return features
+}
+
+func generateFeaturesList(pazuzufileFeatures []string, featuresToInit []string, featuresToAdd []string) ([]string, error) {
+	var features []string
+
+	if len(featuresToInit) > 0 && len(featuresToAdd) > 0 {
+		return features, ErrInitAndAddAreSpecified
+	}
+
+	if len(featuresToInit) > 0 {
+		return featuresToInit, nil
+	}
+
+	if len(featuresToAdd) > 0 {
+		features = pazuzufileFeatures
+		for _, feature := range featuresToAdd {
+			features = appendIfMissing(features, feature)
+		}
+		return features, nil
+	}
+
+	return features, nil
+}
+
+func appendIfMissing(slice []string, element string) []string {
+	for _, next := range slice {
+		if next == element {
+			return slice
+		}
+	}
+	return append(slice, element)
+}
+
+// Reads Pazuzufile
+// returns PazuzuFile struct and a success flag
+func readPazuzuFile() (*pazuzu.PazuzuFile, bool) {
+	file, err := os.Open(PazuzufileName)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	pazuzuFile, err := pazuzu.Read(reader)
+	if err != nil {
+		return nil, false
+	}
+
+	return &pazuzuFile, true
+}
+
+func writePazuzuFile(pazuzuFile *pazuzu.PazuzuFile) error {
+	// TODO: do it safer way (#108)
+	file, err := os.Create(PazuzufileName)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not create %v", PazuzufileName))
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	pazuzu.Write(writer, *pazuzuFile)
+
+	writer.Flush()
+	return nil
+}
+
+func checkFeaturesInRepository(names []string, storage storageconnector.StorageReader) ([]string, error) {
+	var features []string
+
+	for _, name := range names {
+		log.Printf("Checking: %v\n", name)
+
+		_, err := storage.GetMeta(name)
+		if err != nil {
+			return features, errors.New(fmt.Sprintf("Feature %v not found", name))
+		}
+		features = append(features, fmt.Sprintf("%v", name))
+	}
+
+	return features, nil
+}

--- a/cli/pazuzu/utils.go
+++ b/cli/pazuzu/utils.go
@@ -12,9 +12,6 @@ import (
 	"github.com/zalando-incubator/pazuzu/storageconnector"
 )
 
-const PazuzufileName = "Pazuzufile"
-const DockerfileName = "Dockerfile"
-
 func getFeaturesList(featureString string) []string {
 	var features []string
 
@@ -61,8 +58,8 @@ func appendIfMissing(slice []string, element string) []string {
 
 // Reads Pazuzufile
 // returns PazuzuFile struct and a success flag
-func readPazuzuFile() (*pazuzu.PazuzuFile, bool) {
-	file, err := os.Open(PazuzufileName)
+func readPazuzuFile(path string) (*pazuzu.PazuzuFile, bool) {
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, false
 	}
@@ -77,9 +74,9 @@ func readPazuzuFile() (*pazuzu.PazuzuFile, bool) {
 	return &pazuzuFile, true
 }
 
-func writePazuzuFile(pazuzuFile *pazuzu.PazuzuFile) error {
+func writePazuzuFile(path string, pazuzuFile *pazuzu.PazuzuFile) error {
 	// TODO: do it safer way (#108)
-	file, err := os.Create(PazuzufileName)
+	file, err := os.Create(path)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Could not create %v", PazuzufileName))
 	}
@@ -92,8 +89,8 @@ func writePazuzuFile(pazuzuFile *pazuzu.PazuzuFile) error {
 	return nil
 }
 
-func writeDockerFile(contents []byte) error {
-	file, err := os.Create(DockerfileName)
+func writeDockerFile(path string, contents []byte) error {
+	file, err := os.Create(path)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Could not create %v", DockerfileName))
 	}

--- a/cli/pazuzu/utils.go
+++ b/cli/pazuzu/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/zalando-incubator/pazuzu"
@@ -117,4 +118,28 @@ func checkFeaturesInRepository(names []string, storage storageconnector.StorageR
 	}
 
 	return features, nil
+}
+
+// Gets absolute file paths for Pazuzufile and Dockerfile
+// returns Pazuzufile path, Dockerfile path and an error
+func getAbsoluteFilePaths(destination string) (string, string, error) {
+	var pazuzufilePath = PazuzufileName
+	var dockerfilePath = DockerfileName
+
+	if destination != "" {
+		destination, err := filepath.Abs(destination)
+		if err != nil {
+			return "", "", err
+		}
+
+		_, err = os.Stat(destination)
+		if err != nil {
+			err = errors.New(fmt.Sprintf("Destination path %s is not found", destination))
+			return "", "", err
+		}
+
+		pazuzufilePath = filepath.Join(destination, PazuzufileName)
+		dockerfilePath = filepath.Join(destination, DockerfileName)
+	}
+	return pazuzufilePath, dockerfilePath, nil
 }

--- a/cli/pazuzu/utils_test.go
+++ b/cli/pazuzu/utils_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+
+func TestAppendIfMissingWithEmptySlice(t *testing.T) {
+	var emptySlice []string
+	var element = "Test"
+	var result = appendIfMissing(emptySlice, element)
+
+	if len(result) != 1 || result[0] != element {
+		t.Errorf("Wrong result: %s", result)
+	}
+}
+
+func TestAppendIfMissingWithNonEmptySlice(t *testing.T) {
+	var nonEmptySlice = []string{"Existing element"}
+	var element = "Test"
+	var result = appendIfMissing(nonEmptySlice, element)
+
+	if len(result) != 2 || result[1] != element {
+		t.Errorf("Wrong result: %s", result)
+	}
+}
+
+func TestAppendIfMissingDoesNotAppendDuplicate(t *testing.T) {
+	var nonEmptySlice = []string{"Test"}
+	var element = "Test"
+	var result = appendIfMissing(nonEmptySlice, element)
+
+	if len(result) != 1 {
+		t.Errorf("Wrong result: %s", result)
+	}
+}
+
+func TestGenerateFeaturesListFailsWhenBothAddAndInitAreSpecified(t *testing.T) {
+	var pazuzufileFeatures []string
+	var featuresToInit = []string{"a", "b"}
+	var featuresToAdd = []string{"c", "d"}
+
+	_, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+	if err != ErrInitAndAddAreSpecified {
+		t.Error("No error is raised")
+	}
+}
+
+func TestGenerateFeaturesListReturnsFeaturesToInitIfSpecified(t *testing.T) {
+	var pazuzufileFeatures []string
+	var featuresToInit = []string{"a", "b"}
+	var featuresToAdd []string
+
+	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+	if !reflect.DeepEqual(result, featuresToInit) || err != nil {
+		t.Errorf("Result differs from expected: %s", result)
+	}
+}
+
+func TestGenerateFeaturesListReturnsFeaturesToAddIfSpecified(t *testing.T) {
+	var pazuzufileFeatures []string
+	var featuresToInit []string
+	var featuresToAdd = []string{"c", "d"}
+
+	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+	if !reflect.DeepEqual(result, featuresToAdd) || err != nil {
+		t.Errorf("Result differs from expected: %s", result)
+	}
+}
+
+func TestGenerateFeaturesListAddsFeaturesToPazuzuFeatures(t *testing.T) {
+	var pazuzufileFeatures = []string{"a", "b"}
+	var featuresToInit []string
+	var featuresToAdd = []string{"c", "d"}
+	var expectedFeatures = append(pazuzufileFeatures, featuresToAdd...)
+
+	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+	if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
+		t.Errorf("Result differs from expected: %s", result)
+	}
+}
+
+func TestGenerateFeaturesListDoesntAppendDuplicates(t *testing.T) {
+	var pazuzufileFeatures = []string{"a", "b"}
+	var featuresToInit []string
+	var featuresToAdd = []string{"a", "c", "d"}
+	var expectedFeatures = append(pazuzufileFeatures, "c", "d")
+
+	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+	if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
+		t.Errorf("Result differs from expected: %s", result)
+	}
+}
+
+func TestGetFeaturesListReturnsEmptySliceWhenNothingSpecified(t *testing.T) {
+	var badExamples = []string{"", "    ", ", "}
+	for _, example := range badExamples {
+		result := getFeaturesList(example)
+		if len(result) != 0 {
+			t.Errorf("Result should be empty: %s", result)
+		}
+	}
+}
+
+func TestGetFeaturesListReturnsListOfFeatures(t *testing.T) {
+	var featureString = "node,   java,clojure  "
+	var expectedFeatures = []string{"node", "java", "clojure"}
+	var result = getFeaturesList(featureString)
+
+	if !reflect.DeepEqual(result, expectedFeatures) {
+		t.Errorf("Result differs from expected: %s", result)
+	}
+}

--- a/cli/pazuzu/utils_test.go
+++ b/cli/pazuzu/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 )
 
-
 func TestAppendIfMissingWithEmptySlice(t *testing.T) {
 	var emptySlice []string
 	var element = "Test"

--- a/cli/pazuzu/utils_test.go
+++ b/cli/pazuzu/utils_test.go
@@ -5,109 +5,122 @@ import (
 	"testing"
 )
 
-func TestAppendIfMissingWithEmptySlice(t *testing.T) {
-	var emptySlice []string
-	var element = "Test"
-	var result = appendIfMissing(emptySlice, element)
+const checkMark = "\u2713"
 
-	if len(result) != 1 || result[0] != element {
-		t.Errorf("Wrong result: %s", result)
-	}
-}
+func TestAppendIfMissing(t *testing.T) {
+	t.Run("Append to an empty slice", func(t *testing.T) {
+		var emptySlice []string
+		var element = "Test"
+		var result = appendIfMissing(emptySlice, element)
 
-func TestAppendIfMissingWithNonEmptySlice(t *testing.T) {
-	var nonEmptySlice = []string{"Existing element"}
-	var element = "Test"
-	var result = appendIfMissing(nonEmptySlice, element)
-
-	if len(result) != 2 || result[1] != element {
-		t.Errorf("Wrong result: %s", result)
-	}
-}
-
-func TestAppendIfMissingDoesNotAppendDuplicate(t *testing.T) {
-	var nonEmptySlice = []string{"Test"}
-	var element = "Test"
-	var result = appendIfMissing(nonEmptySlice, element)
-
-	if len(result) != 1 {
-		t.Errorf("Wrong result: %s", result)
-	}
-}
-
-func TestGenerateFeaturesListFailsWhenBothAddAndInitAreSpecified(t *testing.T) {
-	var pazuzufileFeatures []string
-	var featuresToInit = []string{"a", "b"}
-	var featuresToAdd = []string{"c", "d"}
-
-	_, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
-	if err != ErrInitAndAddAreSpecified {
-		t.Error("No error is raised")
-	}
-}
-
-func TestGenerateFeaturesListReturnsFeaturesToInitIfSpecified(t *testing.T) {
-	var pazuzufileFeatures []string
-	var featuresToInit = []string{"a", "b"}
-	var featuresToAdd []string
-
-	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
-	if !reflect.DeepEqual(result, featuresToInit) || err != nil {
-		t.Errorf("Result differs from expected: %s", result)
-	}
-}
-
-func TestGenerateFeaturesListReturnsFeaturesToAddIfSpecified(t *testing.T) {
-	var pazuzufileFeatures []string
-	var featuresToInit []string
-	var featuresToAdd = []string{"c", "d"}
-
-	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
-	if !reflect.DeepEqual(result, featuresToAdd) || err != nil {
-		t.Errorf("Result differs from expected: %s", result)
-	}
-}
-
-func TestGenerateFeaturesListAddsFeaturesToPazuzuFeatures(t *testing.T) {
-	var pazuzufileFeatures = []string{"a", "b"}
-	var featuresToInit []string
-	var featuresToAdd = []string{"c", "d"}
-	var expectedFeatures = append(pazuzufileFeatures, featuresToAdd...)
-
-	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
-	if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
-		t.Errorf("Result differs from expected: %s", result)
-	}
-}
-
-func TestGenerateFeaturesListDoesntAppendDuplicates(t *testing.T) {
-	var pazuzufileFeatures = []string{"a", "b"}
-	var featuresToInit []string
-	var featuresToAdd = []string{"a", "c", "d"}
-	var expectedFeatures = append(pazuzufileFeatures, "c", "d")
-
-	result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
-	if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
-		t.Errorf("Result differs from expected: %s", result)
-	}
-}
-
-func TestGetFeaturesListReturnsEmptySliceWhenNothingSpecified(t *testing.T) {
-	var badExamples = []string{"", "    ", ", "}
-	for _, example := range badExamples {
-		result := getFeaturesList(example)
-		if len(result) != 0 {
-			t.Errorf("Result should be empty: %s", result)
+		if len(result) != 1 || result[0] != element {
+			t.Errorf("Wrong result: %s", result)
 		}
-	}
+	}) 
+
+	t.Run("Append to a non-empty slice", func(t *testing.T) {
+		var nonEmptySlice = []string{"Existing element"}
+		var element = "Test"
+		var result = appendIfMissing(nonEmptySlice, element)
+
+		if len(result) != 2 || result[1] != element {
+			t.Errorf("Wrong result: %s", result)
+		}
+	})
+
+	t.Run("Does not append duplicates", func(t *testing.T) {
+		var nonEmptySlice = []string{"Test"}
+		var element = "Test"
+		var result = appendIfMissing(nonEmptySlice, element)
+
+		if len(result) != 1 {
+			t.Errorf("Wrong result: %s", result)
+		}
+	})
 }
 
-func TestGetFeaturesListReturnsListOfFeatures(t *testing.T) {
-	var featureString = "node,   java,clojure  "
-	var expectedFeatures = []string{"node", "java", "clojure"}
-	var result = getFeaturesList(featureString)
 
-	if !reflect.DeepEqual(result, expectedFeatures) {
-		t.Errorf("Result differs from expected: %s", result)
-	}
+func TestGenerateFeaturesList(t *testing.T) {
+
+	t.Run("Fails when both add and init are specified", func(t *testing.T) {
+		var pazuzufileFeatures []string
+		var featuresToInit = []string{"a", "b"}
+		var featuresToAdd = []string{"c", "d"}
+
+		_, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+		if err != ErrInitAndAddAreSpecified {
+			t.Error("No error is raised")
+		}
+	})
+
+
+	t.Run("Returns features to init if specified", func(t *testing.T) {
+		var pazuzufileFeatures []string
+		var featuresToInit = []string{"a", "b"}
+		var featuresToAdd []string
+
+		result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+		if !reflect.DeepEqual(result, featuresToInit) || err != nil {
+			t.Errorf("Result differs from expected: %s", result)
+		}
+	})
+
+	t.Run("Returns features to add if specified", func(t *testing.T) {
+		var pazuzufileFeatures []string
+		var featuresToInit []string
+		var featuresToAdd = []string{"c", "d"}
+
+		result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+		if !reflect.DeepEqual(result, featuresToAdd) || err != nil {
+			t.Errorf("Result differs from expected: %s", result)
+		}
+	})
+
+	t.Run("Adds features to Pazuzufile features", func(t *testing.T) {
+		var pazuzufileFeatures = []string{"a", "b"}
+		var featuresToInit []string
+		var featuresToAdd = []string{"c", "d"}
+		var expectedFeatures = append(pazuzufileFeatures, featuresToAdd...)
+
+		result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+		if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
+			t.Errorf("Result differs from expected: %s", result)
+		}
+	})
+
+	t.Run("Does not append duplicates", func(t *testing.T) {
+		var pazuzufileFeatures = []string{"a", "b"}
+		var featuresToInit []string
+		var featuresToAdd = []string{"a", "c", "d"}
+		var expectedFeatures = append(pazuzufileFeatures, "c", "d")
+
+		result, err := generateFeaturesList(pazuzufileFeatures, featuresToInit, featuresToAdd)
+		if !reflect.DeepEqual(result, expectedFeatures) || err != nil {
+			t.Errorf("Result differs from expected: %s", result)
+		}
+	})
+}
+
+
+func TestGetFeaturesList(t *testing.T) {
+	t.Run("Returns empty slice when nothing is specified", func(t *testing.T) {
+		var badExamples = []string{"", "    ", ", "}
+		for _, example := range badExamples {
+			result := getFeaturesList(example)
+			if len(result) != 0 {
+				t.Errorf("Result should be empty: %s", result)
+			}
+			t.Logf("%s Example \"%s\"", checkMark, example)
+		}
+	})
+
+	t.Run("Returns list of features", func(t *testing.T) {
+		var featureString = "node,   java,clojure  "
+		var expectedFeatures = []string{"node", "java", "clojure"}
+		var result = getFeaturesList(featureString)
+
+		if !reflect.DeepEqual(result, expectedFeatures) {
+			t.Errorf("Result differs from expected: %s", result)
+		}
+	})
 }

--- a/pazuzu.go
+++ b/pazuzu.go
@@ -100,7 +100,6 @@ func (p *Pazuzu) generateDockerfile(baseimage string, features []storageconnecto
 		if err != nil {
 			return err
 		}
-		fmt.Print(feature.Meta)
 
 		err = writer.AppendFeature(feature)
 		if err != nil {


### PR DESCRIPTION
Implements #102 

📙 

- Updates look and feel of `pazuzu compose`
- Resolves conflicts between `-i` and `-a` options
- Makes `pazuzu compose` more modular
- Generates `Dockerfiles` from `pazuzu compose`

### How to test
1. Play around CLI
   ```bash
   cd cli/pazuzu
   go build
   ./pazuzu compose -i node,java
   ./pazuzu compose -a node,java
   ./pazuzu compose -a node,java -i node,java   # returns error
   ```

2. Observe `Pazuzufile` and `Dockerfile` are created
