### PR TITLE
HOTFIX: Fix dependencies in config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,8 +11,12 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"github.com/zalando-incubator/pazuzu/storageconnector"
+
+	"github.com/jinzhu/copier"
+	"github.com/cevaris/ordered_map"
 	"gopkg.in/yaml.v2"
+
+	"github.com/zalando-incubator/pazuzu/storageconnector"
 )
 
 const (


### PR DESCRIPTION
Reverted missing dependencies to `config.go`