### PR TITLE
Run `go fmt` Against Current Codebase

### DIFF
--- a/cli/pazuzu/build.go
+++ b/cli/pazuzu/build.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/urfave/cli"
-	"github.com/zalando-incubator/pazuzu"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/urfave/cli"
+	"github.com/zalando-incubator/pazuzu"
 )
 
 // Fetches and builds features into a docker image.
@@ -28,7 +29,7 @@ func buildFeatures(c *cli.Context) error {
 
 	p := pazuzu.Pazuzu{StorageReader: storageReader,
 		DockerEndpoint: "unix:///var/run/docker.sock",
-		Dockerfile:dat,
+		Dockerfile:     dat,
 	}
 
 	name := "pazuzu image"
@@ -41,4 +42,3 @@ func buildFeatures(c *cli.Context) error {
 	}
 	return nil
 }
-

--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -14,7 +14,7 @@ const (
 	PazuzufileName   = "Pazuzufile"
 	DockerfileName   = "Dockerfile"
 	TestSpecFileName = "test.bats"
-	directoryOption = "directory"
+	directoryOption  = "directory"
 )
 
 var cnfGetCmd = cli.Command{
@@ -180,7 +180,7 @@ var composeCmd = cli.Command{
 	Action: composeAction,
 }
 
-var buildFlags = []cli.Flag {
+var buildFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "d, directory",
 		Usage: "Sets source path where Docketfile are located.",
@@ -189,13 +189,12 @@ var buildFlags = []cli.Flag {
 		Name:  "n, name",
 		Usage: "Sets a name for docker image",
 	},
-
 }
 
 var buildCmd = cli.Command{
 	Name:      "build",
 	Usage:     "Builds and tests Docker image from Dockerfile",
 	ArgsUsage: " ",
-	Flags: buildFlags,
+	Flags:     buildFlags,
 	Action:    buildFeatures,
 }

--- a/config.go
+++ b/config.go
@@ -97,8 +97,8 @@ func InitDefaultConfig() {
 		StorageType: "git",
 		Base:        BaseImage,
 		Git:         GitConfig{URL: URL},
-		Memory:      MemoryConfig{InitialiseRandom: false,},
-		PostgreSQL:  PostgreSQLConfig{ConnectionString: ConnectionString, },
+		Memory:      MemoryConfig{InitialiseRandom: false},
+		PostgreSQL:  PostgreSQLConfig{ConnectionString: ConnectionString},
 	}
 }
 

--- a/pazuzu_test.go
+++ b/pazuzu_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
 	"github.com/zalando-incubator/pazuzu/shared"
 )
 

--- a/shared/feature.go
+++ b/shared/feature.go
@@ -17,7 +17,7 @@ type FeatureMeta struct {
 // Feature is a definition for a piece of work to be done. Contains meta information as well as
 // all necessary data to compose a piece of Dockerfile at the end.
 type Feature struct {
-	Meta         FeatureMeta
-	Snippet      string
-	TestSnippet  string
+	Meta        FeatureMeta
+	Snippet     string
+	TestSnippet string
 }

--- a/shared/testspecs.go
+++ b/shared/testspecs.go
@@ -24,7 +24,6 @@ var BatsFeature = Feature{
 	Snippet: batsSnippet,
 }
 
-
 func ReadTestSpec(reader io.Reader) string {
 	var scanner = bufio.NewScanner(reader)
 	var buffer = bytes.NewBufferString("")

--- a/shared/testspecs_test.go
+++ b/shared/testspecs_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 const testSpecFixture = `#!/usr/bin/env bats
 
 @test "Check that Java is installed" {  
@@ -31,7 +30,6 @@ func TestReadTestSpec(t *testing.T) {
 		expectedTestSpec := "@test \"Check that Java is installed\" {\n" +
 			"    command java -version\n" +
 			"}"
-
 
 		assert.Equal(t, result, expectedTestSpec, "Result mismatched")
 	})

--- a/storageconnector/gitstorage.go
+++ b/storageconnector/gitstorage.go
@@ -18,7 +18,7 @@ const (
 	featureFile              = "meta.yml"   // name of the file containing all metadata for a feature.
 	featureSnippet           = "Dockerfile" // the file containing the actual docker snippet.
 	testSnippet              = "test.bats"  // the file containing the bats test specification (https://github.com/sstephenson/bats)
-	defaultSearchParamsLimit = 100 // we should use this constant
+	defaultSearchParamsLimit = 100          // we should use this constant
 )
 
 // yamlFeatureMeta is used for unmarshalling of meta.yml files.
@@ -191,9 +191,9 @@ func getFeature(commit *git.Commit, name string) (shared.Feature, error) {
 	testSnippet := getTestSpec(commit, name)
 
 	return shared.Feature{
-		Meta:         meta,
-		Snippet:      string(snippet),
-		TestSnippet:  string(testSnippet),
+		Meta:        meta,
+		Snippet:     string(snippet),
+		TestSnippet: string(testSnippet),
 	}, nil
 }
 
@@ -220,14 +220,14 @@ func (storage *GitStorage) Resolve(names ...string) ([]string, map[string]shared
 
 	commit, err := storage.latestCommit()
 	if err != nil {
-		return []string {}, map[string]shared.Feature{}, err
+		return []string{}, map[string]shared.Feature{}, err
 	}
 
 	result := map[string]shared.Feature{}
 	for _, name := range names {
 		err = resolve(commit, name, &slice, result)
 		if err != nil {
-			return []string {}, map[string]shared.Feature{}, err
+			return []string{}, map[string]shared.Feature{}, err
 		}
 	}
 


### PR DESCRIPTION
No ticket, just a small clean-up

🔋 

Formats the existing codebase according to Go standards