### PR TITLE
PAZUZU-175 Do not throw panic in integer config changes

### DIFF
--- a/cli/pazuzu/commands.go
+++ b/cli/pazuzu/commands.go
@@ -56,8 +56,7 @@ func setConfig(c *cli.Context) error {
 		_ = cfg.Save()
 		return nil
 	}
-	fmt.Printf("FAIL [%v]\n", errSet)
-	return pazuzu.ErrNotFound
+	return errSet
 }
 
 func getConfig(c *cli.Context) error {

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -128,4 +129,17 @@ func TestConfigUserConfigFilename(t *testing.T) {
 func getConfigMirror(t *testing.T) *ConfigMirror {
 	cfg := getConfig(t)
 	return cfg.InitConfigFieldMirrors()
+}
+
+func dummySetterWithInteger(value int) {}
+
+func TestValueToReflectValue(t *testing.T) {
+	setter := reflect.ValueOf(dummySetterWithInteger)
+	val, err := valToReflectValue(setter, "10")
+	if err != nil {
+		t.Error("Couldn't handle integer parameter type")
+	}
+	if val.Int() != reflect.ValueOf(10).Int() {
+		t.Error("Couldn't parse integer correctly.")
+	}
 }

--- a/error.go
+++ b/error.go
@@ -9,4 +9,5 @@ var (
 	ErrStopIteration          = errors.New("It's not an real error, sorry!")
 	ErrNotFound               = errors.New("Not found")
 	ErrInitAndAddAreSpecified = errors.New("Conflict: both `add` and `init` parameters are specified")
+	ErrInvalidConfigValue     = errors.New("Can not parse value to required type")
 )


### PR DESCRIPTION
Solves #175 
This was harder than I thought. We are using `reflect` for config setting and this forces us to determine value type at runtime.
PS: I think `valToReflectValue` is open to improve enough to support other types like `boolean` if we need in future. Any suggestions are welcomed :)