### PR TITLE
PAZUZU-132 Run test specs at build

### DIFF
--- a/cli/pazuzu/compose.go
+++ b/cli/pazuzu/compose.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/urfave/cli"
 	"github.com/zalando-incubator/pazuzu"
+	"github.com/zalando-incubator/pazuzu/shared"
 )
 
 var composeAction = func(c *cli.Context) error {
@@ -28,6 +29,7 @@ var composeAction = func(c *cli.Context) error {
 
 	pazuzufilePath := getAbsoluteFilePath(destination, PazuzufileName)
 	dockerfilePath := getAbsoluteFilePath(destination, DockerfileName)
+	testSpecPath := getAbsoluteFilePath(destination, shared.TestSpecFilename)
 
 	pazuzuFile, success := readPazuzuFile(pazuzufilePath)
 	if success {
@@ -76,6 +78,10 @@ var composeAction = func(c *cli.Context) error {
 	p.Generate(pazuzuFile.Base, pazuzuFile.Features)
 
 	err = writeFile(dockerfilePath, p.Dockerfile)
+
+	fmt.Printf("Generating %s...", testSpecPath)
+	err = writeFile(testSpecPath, p.TestSpec)
+
 	if err != nil {
 		return err
 	} else {

--- a/pazuzu.go
+++ b/pazuzu.go
@@ -8,11 +8,17 @@ import (
 	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
-	"os"
 	"time"
 
 	"github.com/zalando-incubator/pazuzu/shared"
 	"github.com/zalando-incubator/pazuzu/storageconnector"
+	"os"
+	"os/exec"
+)
+
+const (
+	tempDir    = "/tmp/pazuzu/"
+	mountPoint = "/pazuzu/"
 )
 
 // Pazuzu defines pazuzu config.
@@ -78,6 +84,10 @@ func (p *Pazuzu) Generate(baseimage string, features []string) error {
 
 	err := p.generateDockerfile(baseimage, featuresWithDep)
 	if err != nil {
+		return err
+	}
+
+	if err := p.generateTestSpec(featuresWithDep); err != nil {
 		return err
 	}
 
@@ -156,6 +166,163 @@ func (p *Pazuzu) DockerBuild(name string) error {
 	err2 := client.BuildImage(opts)
 	if err2 != nil {
 		fmt.Errorf("Error: %s", err2)
+		return err
+	}
+
+	p.testDockerImage(name)
+
+	return nil
+}
+
+func (p *Pazuzu) dockerExec(ID string, cmd string) error {
+	execOpts := docker.CreateExecOptions{
+		Container:    ID,
+		AttachStdin:  false,
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd: []string{
+			"/bin/bash",
+			"-c",
+			cmd,
+		},
+		Tty: true,
+	}
+	exec, err := p.docker.CreateExec(execOpts)
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	var errBuf bytes.Buffer
+
+	startExecOpts := docker.StartExecOptions{
+		Detach:       false,
+		OutputStream: os.Stdout,
+		ErrorStream:  &errBuf,
+		RawTerminal:  true,
+		Tty:          true,
+	}
+
+	err = p.docker.StartExec(exec.ID, startExecOpts)
+	if err != nil {
+		return err
+	}
+
+	inspect, err := p.docker.InspectExec(exec.ID)
+	if err != nil {
+		return err
+	}
+
+	if inspect.ExitCode > 0 {
+		return fmt.Errorf("exit code %d: %s", inspect.ExitCode, buf.String())
+	}
+
+	return nil
+}
+
+func (p *Pazuzu) dockerStart(image string) (*docker.Container, error) {
+	var err error
+	p.docker, err = docker.NewClient(p.DockerEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	opts := docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image: image,
+			Tty:   true,
+			Cmd: []string{
+				"/bin/sh",
+			},
+		},
+		HostConfig: &docker.HostConfig{
+			Binds: []string{
+				tempDir + ":" + mountPoint,
+			},
+		},
+	}
+
+	container, err := p.docker.CreateContainer(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.docker.StartContainer(container.ID, nil); err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}
+
+func (p *Pazuzu) dockerStop(ID string) error {
+	if err := p.docker.StopContainer(ID, 1); err != nil {
+		return err
+	}
+
+	if err := p.docker.RemoveContainer(docker.RemoveContainerOptions{
+		ID: ID,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Pazuzu) generateTestSpec(features []shared.Feature) error {
+	var buffer = bytes.NewBufferString("")
+	if err := shared.WriteTestSpec(buffer, features); err != nil {
+		return err
+	}
+	p.TestSpec = buffer.Bytes()
+	return nil
+}
+
+func (p *Pazuzu) testDockerImage(image string) error {
+	os.MkdirAll(tempDir, 0777)
+
+	batsZip := tempDir + "master.zip"
+
+	if err := exec.Command(
+		"wget",
+		"https://github.com/sstephenson/bats/archive/master.zip",
+		"-O", batsZip).Run(); err != nil {
+		fmt.Println("Couldn't download bats")
+		return err
+	}
+	if err := exec.Command("unzip", "-o", batsZip, "-d", tempDir).Run(); err != nil {
+		fmt.Println("Couldn't unzip bats to " + tempDir)
+		return err
+	}
+	if err := exec.Command("rm", batsZip).Run(); err != nil {
+		fmt.Println("Couldn't delete master.zip")
+		return err
+	}
+	if err := exec.Command("cp", shared.TestSpecFilename, tempDir).Run(); err != nil {
+		fmt.Println("Couldn't copy test.bats file to " + tempDir)
+		return err
+	}
+
+	container, err := p.dockerStart(image)
+	if err != nil {
+		fmt.Println("Couldn't start docker container")
+		fmt.Println(err)
+		return err
+	}
+
+	if err := p.dockerExec(
+		container.ID,
+		fmt.Sprintf("%sbats-master/install.sh /usr/local && /usr/local/bin/bats -p %s%s", mountPoint, mountPoint, shared.TestSpecFilename)); err != nil {
+		fmt.Println("Couldn't exec test commands on container")
+		fmt.Println(err)
+		return err
+	}
+
+	if err := p.dockerStop(container.ID); err != nil {
+		fmt.Println("Couldn't stop container")
+		return err
+	}
+
+	if err := os.RemoveAll(tempDir); err != nil {
+		fmt.Println("Couldn't delete " + tempDir)
 		return err
 	}
 

--- a/shared/testspecs.go
+++ b/shared/testspecs.go
@@ -1,0 +1,28 @@
+package shared
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	shebang          = "#!/usr/bin/env bats"
+	TestSpecFilename = "test.bats"
+)
+
+func WriteTestSpec(writer io.Writer, features []Feature) error {
+	var lines = []string{shebang}
+
+	for _, feature := range features {
+		lines = append(lines, feature.TestSnippet)
+	}
+
+	for _, line := range lines {
+		_, err := fmt.Fprintf(writer, "%s\n\n", line)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Previous approach was assuming the base image is ubuntu(needs `apt-get`) and was installing git while building the docker image which I wouldn't be happy if trying to create a minimal image.

So with new approach we are only assuming that host has `wget` and `unzip`

Now test flow is:
1) Download and unzip bats to host(`/tmp/pazuzu`).
2) Copy test specs file to `/tmp/pazuzu`.
3) Run a docker container from built image.
4) Mount `/tmp/pazuzu` to `/pazuzu` on container.
5) Install bats and run tests.
6) Delete temp dir on host.
7) Stop container.
