### PR TITLE
Start command usage with a capital letter

### DIFF
--- a/cli/pazuzu/command/clean/clean.go
+++ b/cli/pazuzu/command/clean/clean.go
@@ -10,8 +10,7 @@ import (
 
 var Command = cli.Command{
   Name: "clean",
-  Aliases: []string{"cl"},
-  Usage: "remove Pazuzufile and Dockerfile",
+  Usage: "Remove Pazuzufile and Dockerfile",
   Action: cleanAction,
 }
 

--- a/cli/pazuzu/command/search/search.go
+++ b/cli/pazuzu/command/search/search.go
@@ -11,7 +11,7 @@ import (
 
 var Command = cli.Command{
 	Name:      "search",
-	Usage:     "search for features in registry",
+	Usage:     "Search for features in registry",
 	ArgsUsage: "[regexp] - Regexp to be used for feature lookup",
 	Action: searchAction,
 }
@@ -48,4 +48,3 @@ var searchAction = func(c *cli.Context) error {
 
 	return nil
 }
-


### PR DESCRIPTION
I also removed the alias for clean as other commands don't use this