### PR TITLE
Improvements for search action

### DIFF
--- a/cli/pazuzu/actions/search.go
+++ b/cli/pazuzu/actions/search.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"github.com/urfave/cli"
 	"github.com/zalando-incubator/pazuzu/config"
+	"github.com/zalando-incubator/pazuzu/shared"
+	storage "github.com/zalando-incubator/pazuzu/storageconnector"
 	"os"
 	"regexp"
 	"text/tabwriter"
@@ -14,21 +16,18 @@ func Search(c *cli.Context) error {
 	if c.NArg() != 1 {
 		return errors.New("Search regexp is not provided")
 	}
-	feature := c.Args().First()
-	featureRegexp, err := regexp.Compile(feature)
-	if err != nil {
-		return errors.New("Can't compile search regexp")
-	}
-
+	featureName := c.Args().First()
 	cfg := config.GetConfig()
 	storage, err := config.GetStorageReader(*cfg)
 	if err != nil {
 		return errors.New("Can't create storage reader")
 	}
-	features, err := storage.SearchMeta(featureRegexp)
+
+	features, err := SearchHandler(featureName, storage)
 	if err != nil {
 		return errors.New("Can't execute search request")
 	}
+
 	if len(features) == 0 {
 		fmt.Println("No features found")
 		return nil
@@ -41,4 +40,18 @@ func Search(c *cli.Context) error {
 	}
 	writer.Flush()
 	return nil
+}
+
+func SearchHandler(feature string, storage storage.StorageReader) ([]shared.FeatureMeta, error) {
+	featureRegexp, err := regexp.Compile(feature)
+	if err != nil {
+		return nil, errors.New("Can't compile search regexp")
+	}
+
+	features, err := storage.SearchMeta(featureRegexp)
+	if err != nil {
+		return nil, errors.New("Can't execute search request")
+	}
+
+    return features, nil
 }

--- a/cli/pazuzu/actions/search_test.go
+++ b/cli/pazuzu/actions/search_test.go
@@ -1,0 +1,41 @@
+package actions
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zalando-incubator/pazuzu"
+	"github.com/zalando-incubator/pazuzu/shared"
+)
+
+func TestSearchHandler(t *testing.T) {
+	type args struct {
+		feature string
+		storage *pazuzu.TestStorage
+	}
+
+	featureMeta := pazuzu.GetTestFeatureMeta()
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []shared.FeatureMeta
+		wantErr bool
+	}{
+		{"Plain argument", args{"python", &pazuzu.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
+		{"Regex argument", args{"pyth*", &pazuzu.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
+		{"Incorrect regex", args{"pyth)", &pazuzu.TestStorage{}}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SearchHandler(tt.args.feature, tt.args.storage)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchHandler() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchHandler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/pazuzu/actions/search_test.go
+++ b/cli/pazuzu/actions/search_test.go
@@ -4,17 +4,17 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/zalando-incubator/pazuzu"
 	"github.com/zalando-incubator/pazuzu/shared"
+	"github.com/zalando-incubator/pazuzu/mock"
 )
 
 func TestSearchHandler(t *testing.T) {
 	type args struct {
 		feature string
-		storage *pazuzu.TestStorage
+		storage *mock.TestStorage
 	}
 
-	featureMeta := pazuzu.GetTestFeatureMeta()
+	featureMeta := mock.GetTestFeatureMeta()
 
 	tests := []struct {
 		name    string
@@ -22,9 +22,9 @@ func TestSearchHandler(t *testing.T) {
 		want    []shared.FeatureMeta
 		wantErr bool
 	}{
-		{"Plain argument", args{"python", &pazuzu.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
-		{"Regex argument", args{"pyth*", &pazuzu.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
-		{"Incorrect regex", args{"pyth)", &pazuzu.TestStorage{}}, nil, true},
+		{"Plain argument", args{"python", &mock.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
+		{"Regex argument", args{"pyth*", &mock.TestStorage{}}, []shared.FeatureMeta{featureMeta}, false},
+		{"Incorrect regex", args{"pyth)", &mock.TestStorage{}}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mock/storage.go
+++ b/mock/storage.go
@@ -1,4 +1,4 @@
-package pazuzu
+package mock
 
 import (
 	"regexp"

--- a/mock_storage.go
+++ b/mock_storage.go
@@ -1,0 +1,37 @@
+package pazuzu
+
+import (
+	"regexp"
+
+	"github.com/zalando-incubator/pazuzu/shared"
+)
+
+type TestStorage struct{}
+
+var pythonFeatureMeta = shared.FeatureMeta{
+    Name:        "python",
+    Description: "Use `python -V`",
+}
+
+func GetTestFeatureMeta() shared.FeatureMeta {
+    return pythonFeatureMeta
+}
+
+func (s *TestStorage) GetFeature(feature string) (shared.Feature, error) {
+	return shared.Feature{
+		Meta: pythonFeatureMeta,
+		Snippet: "RUN apt-get update && apt-get install python --yes",
+	}, nil
+}
+
+func (s *TestStorage) GetMeta(name string) (shared.FeatureMeta, error) {
+	return pythonFeatureMeta, nil
+}
+
+func (s *TestStorage) SearchMeta(name *regexp.Regexp) ([]shared.FeatureMeta, error) {
+	return []shared.FeatureMeta {pythonFeatureMeta}, nil
+}
+
+func (s *TestStorage) Resolve(names ...string) ([]string, map[string]shared.Feature, error) {
+	return []string{}, make(map[string]shared.Feature), nil
+}

--- a/pazuzu_test.go
+++ b/pazuzu_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/zalando-incubator/pazuzu/shared"
+	"github.com/zalando-incubator/pazuzu/mock"
 	"io/ioutil"
 )
 
 // Test generating a Dockerfile from a list of features.
 func TestGenerate(t *testing.T) {
 	pazuzu := Pazuzu{
-		StorageReader: &TestStorage{},
+		StorageReader: &mock.TestStorage{},
 		testSpec:      "test_spec.json",
 	}
 

--- a/pazuzu_test.go
+++ b/pazuzu_test.go
@@ -2,40 +2,12 @@ package pazuzu
 
 import (
 	"bytes"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/zalando-incubator/pazuzu/shared"
 	"io/ioutil"
 )
-
-type TestStorage struct{}
-
-func (s *TestStorage) GetFeature(feature string) (shared.Feature, error) {
-	return shared.Feature{
-		Meta: shared.FeatureMeta{
-			Name:        "python",
-			Description: "Use `python -V`",
-		},
-		Snippet: "RUN apt-get update && apt-get install python --yes",
-	}, nil
-}
-
-func (s *TestStorage) GetMeta(name string) (shared.FeatureMeta, error) {
-	return shared.FeatureMeta{
-		Name:        "python",
-		Description: "Use `python -V`",
-	}, nil
-}
-
-func (s *TestStorage) SearchMeta(name *regexp.Regexp) ([]shared.FeatureMeta, error) {
-	return make([]shared.FeatureMeta, 0), nil
-}
-
-func (s *TestStorage) Resolve(names ...string) ([]string, map[string]shared.Feature, error) {
-	return []string{}, make(map[string]shared.Feature), nil
-}
 
 // Test generating a Dockerfile from a list of features.
 func TestGenerate(t *testing.T) {


### PR DESCRIPTION
* split up the code of `Search` action into two parts - one for input validation and output, another for actually perform search. It should make it more aligned with the idea of one responsibility for one function, and more testable (we don't need to pass cli object to our test, it's possible to use feature name instead).

* move out `TestStorage` to a separate module and use it when necessary

* add few test cases for `Search` action