### PR TITLE
Move out few hardcoded constants.

### DIFF
--- a/cli/pazuzu/actions/project.go
+++ b/cli/pazuzu/actions/project.go
@@ -68,7 +68,7 @@ func ProjectBuild(c *cli.Context) error {
 		return fmt.Errorf("Error during attempt to read docker file:%s", err)
 	}
 
-	p.DockerEndpoint = "unix:///var/run/docker.sock"
+	p.DockerEndpoint = pazuzu.DefaultDockerEndpoint
 	p.Dockerfile = dat
 
 	name := ""

--- a/storageconnector/registryconnector.go
+++ b/storageconnector/registryconnector.go
@@ -12,6 +12,11 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 )
 
+const (
+	DefaultApiPath = "/api"
+)
+
+
 type registryStorage struct {
 	Hostname string // localhost
 	Port     int    // 8080
@@ -28,7 +33,7 @@ func (store *registryStorage) init(hostname string, port int, scheme string, for
 	store.Scheme = scheme
 
 	host := hostname + ":" + strconv.Itoa(port)
-	path := "/api"
+	path := DefaultApiPath
 	schemes := []string{scheme}
 
 	transport := httptransport.New(host, path, schemes)


### PR DESCRIPTION
Few of them was used only for the testing purposes (like `DefaultShell`
in `pazuzu.go`), but I believe that it's not an excuse, since tests also
should be clean. The same for `MakeShellCommand` function.